### PR TITLE
set locale to UTF-8 to prevent jekyll Invalid character "\xE2"

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+export LC_ALL="en_US.UTF-8"
+export LANG="en_US.UTF-8"
+export LANGUAGE="en_US.UTF-8"
 bundle exec jekyll serve


### PR DESCRIPTION
 when running within Intellij